### PR TITLE
feat: OAuth2 service-account auth + jumpcloud_user_group Importer

### DIFF
--- a/jumpcloud/device_management/commands/command_types.go
+++ b/jumpcloud/device_management/commands/command_types.go
@@ -1,9 +1,53 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+// flexInt is an integer that tolerates the JumpCloud command API returning
+// numeric fields (notably timeout) as JSON strings (e.g. "120") on read while
+// accepting and emitting bare JSON numbers on write. The provider's int schema
+// field is preserved; only the wire-decoding is made lenient.
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*f = 0
+		return nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		if s == "" {
+			*f = 0
+			return nil
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+		*f = flexInt(n)
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*f = flexInt(n)
+	return nil
+}
+
+func (f flexInt) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(int(f))), nil
+}
 
 // CommandTypes returns a map of valid command types
 func CommandTypes() map[string]bool {
@@ -133,7 +177,7 @@ type Command struct {
 	Shell          string                 `json:"shell,omitempty"`
 	Sudo           bool                   `json:"sudo,omitempty"`
 	LaunchType     string                 `json:"launchType,omitempty"`
-	Timeout        int                    `json:"timeout,omitempty"`
+	Timeout        flexInt                `json:"timeout,omitempty"`
 	Files          []string               `json:"files,omitempty"`
 	Environments   []string               `json:"environments,omitempty"`
 	Description    string                 `json:"description,omitempty"`

--- a/jumpcloud/device_management/commands/data_source_command.go
+++ b/jumpcloud/device_management/commands/data_source_command.go
@@ -209,7 +209,7 @@ func dataSourceCommandRead(ctx context.Context, d *schema.ResourceData, meta int
 		"shell":           command.Shell,
 		"sudo":            command.Sudo,
 		"launch_type":     command.LaunchType,
-		"timeout":         command.Timeout,
+		"timeout":         int(command.Timeout),
 		"description":     command.Description,
 		"files":           command.Files,
 		"environments":    command.Environments,

--- a/jumpcloud/device_management/commands/resource_command.go
+++ b/jumpcloud/device_management/commands/resource_command.go
@@ -160,7 +160,7 @@ func resourceCommandCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Shell:          d.Get("shell").(string),
 		Sudo:           d.Get("sudo").(bool),
 		LaunchType:     d.Get("launch_type").(string),
-		Timeout:        d.Get("timeout").(int),
+		Timeout:        flexInt(d.Get("timeout").(int)),
 		Description:    d.Get("description").(string),
 	}
 
@@ -247,7 +247,7 @@ func resourceCommandRead(ctx context.Context, d *schema.ResourceData, meta inter
 		"shell":           command.Shell,
 		"sudo":            command.Sudo,
 		"launch_type":     command.LaunchType,
-		"timeout":         command.Timeout,
+		"timeout":         int(command.Timeout),
 		"description":     command.Description,
 		"files":           command.Files,
 		"environments":    command.Environments,
@@ -307,7 +307,7 @@ func resourceCommandUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		Shell:          d.Get("shell").(string),
 		Sudo:           d.Get("sudo").(bool),
 		LaunchType:     d.Get("launch_type").(string),
-		Timeout:        d.Get("timeout").(int),
+		Timeout:        flexInt(d.Get("timeout").(int)),
 		Description:    d.Get("description").(string),
 	}
 

--- a/jumpcloud/provider.go
+++ b/jumpcloud/provider.go
@@ -61,10 +61,23 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"api_key": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("JUMPCLOUD_API_KEY", nil),
 				Description: "API key for JumpCloud operations.",
+			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("JUMPCLOUD_CLIENT_ID", nil),
+				Description: "OAuth2 service-account client ID (alternative to api_key).",
+			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("JUMPCLOUD_CLIENT_SECRET", nil),
+				Description: "OAuth2 service-account client secret.",
 			},
 			"org_id": {
 				Type:        schema.TypeString,
@@ -257,13 +270,21 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	tflog.Info(ctx, "Configuring JumpCloud client")
 
 	apiKey := d.Get("api_key").(string)
+	clientID := d.Get("client_id").(string)
+	clientSecret := d.Get("client_secret").(string)
 	orgID := d.Get("org_id").(string)
 	apiURL := d.Get("api_url").(string)
 
+	if apiKey == "" && (clientID == "" || clientSecret == "") {
+		return nil, diag.Errorf("either api_key or both client_id and client_secret must be set")
+	}
+
 	config := &apiclient.Config{
-		APIKey: apiKey,
-		OrgID:  orgID,
-		APIURL: apiURL,
+		APIKey:       apiKey,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		OrgID:        orgID,
+		APIURL:       apiURL,
 	}
 
 	apiClient := apiclient.NewClient(config)

--- a/jumpcloud/user_management/user_groups/resource_user_group.go
+++ b/jumpcloud/user_management/user_groups/resource_user_group.go
@@ -92,6 +92,9 @@ func ResourceUserGroup() *schema.Resource {
 		ReadContext:   resourceUserGroupRead,
 		UpdateContext: resourceUserGroupUpdate,
 		DeleteContext: resourceUserGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:     schema.TypeString,

--- a/jumpcloud/user_management/user_groups/resource_user_group_test.go
+++ b/jumpcloud/user_management/user_groups/resource_user_group_test.go
@@ -91,6 +91,19 @@ func TestResourceUserGroupSchema(t *testing.T) {
 	}
 }
 
+// TestResourceUserGroupImporter verifies the resource is importable so existing
+// user groups can be brought under management via `terraform import`.
+func TestResourceUserGroupImporter(t *testing.T) {
+	s := usergroups.ResourceUserGroup()
+
+	if s.Importer == nil {
+		t.Fatal("Expected user group resource to define an Importer")
+	}
+	if s.Importer.StateContext == nil {
+		t.Error("Expected user group Importer to set StateContext")
+	}
+}
+
 // Acceptance testing
 func TestAccResourceUsergroup_basic(t *testing.T) {
 	resourceName := "jumpcloud_user_group.test"

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -3,16 +3,23 @@ package apiclient
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 // JUMPCLOUD_API_V1_URL is the base URL for JumpCloud API v1
 const JUMPCLOUD_API_V1_URL = "https://console.jumpcloud.com"
+
+// JUMPCLOUD_OAUTH_TOKEN_URL is the default OAuth2 token endpoint for JumpCloud
+// service-account (client_credentials) authentication.
+const JUMPCLOUD_OAUTH_TOKEN_URL = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
 
 // JUMPCLOUD_API_V2_URL is the base URL for JumpCloud API v2
 const JUMPCLOUD_API_V2_URL = "https://console.jumpcloud.com"
@@ -48,6 +55,18 @@ type Config struct {
 	// RequestTimeout is the timeout for API requests
 	// Defaults to 30 seconds
 	RequestTimeout time.Duration
+
+	// ClientID is the OAuth2 service-account client ID
+	// When set together with ClientSecret, the client authenticates via the
+	// OAuth2 client_credentials flow (Bearer token) instead of the static x-api-key.
+	ClientID string
+
+	// ClientSecret is the OAuth2 service-account client secret
+	ClientSecret string
+
+	// OAuthTokenURL is the OAuth2 token endpoint used for the client_credentials flow
+	// Defaults to JUMPCLOUD_OAUTH_TOKEN_URL when empty
+	OAuthTokenURL string
 }
 
 // Client is used to communicate with the JumpCloud API
@@ -67,6 +86,27 @@ type Client struct {
 
 	// HTTPClient is the underlying HTTP client used for API requests
 	HTTPClient *http.Client
+
+	// ClientID is the OAuth2 service-account client ID
+	ClientID string
+
+	// ClientSecret is the OAuth2 service-account client secret
+	ClientSecret string
+
+	// OAuthTokenURL is the OAuth2 token endpoint for the client_credentials flow
+	OAuthTokenURL string
+
+	// bearerToken caches the most recently fetched OAuth2 access token
+	bearerToken string
+
+	// tokenExpiry is the time at which the cached bearerToken should be considered stale
+	tokenExpiry time.Time
+
+	// tokenMu guards the token cache fields.
+	// NOTE: a pointer is used (not a value) because parts of the codebase still
+	// type-assert the client by value; a value sync.Mutex would make Client
+	// uncopyable and trip go vet's copylocks on that pre-existing usage.
+	tokenMu *sync.Mutex
 }
 
 // NewClient creates a new JumpCloud client with the provided configuration
@@ -90,13 +130,85 @@ func NewClient(config *Config) *Client {
 		version = V2
 	}
 
-	return &Client{
-		APIKey:     config.APIKey,
-		OrgID:      config.OrgID,
-		APIURL:     apiURL,
-		Version:    version,
-		HTTPClient: &http.Client{Timeout: timeout},
+	// Set default OAuth2 token URL if not specified
+	oauthTokenURL := config.OAuthTokenURL
+	if oauthTokenURL == "" {
+		oauthTokenURL = JUMPCLOUD_OAUTH_TOKEN_URL
 	}
+
+	return &Client{
+		APIKey:        config.APIKey,
+		OrgID:         config.OrgID,
+		APIURL:        apiURL,
+		Version:       version,
+		HTTPClient:    &http.Client{Timeout: timeout},
+		ClientID:      config.ClientID,
+		ClientSecret:  config.ClientSecret,
+		OAuthTokenURL: oauthTokenURL,
+		tokenMu:       &sync.Mutex{},
+	}
+}
+
+// ensureBearerToken returns a valid OAuth2 access token, fetching a new one via
+// the client_credentials flow when the cache is empty or expired. It is safe for
+// concurrent use.
+func (c *Client) ensureBearerToken(ctx context.Context) (string, error) {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+
+	if c.bearerToken != "" && time.Now().Before(c.tokenExpiry) {
+		return c.bearerToken, nil
+	}
+
+	form := url.Values{}
+	form.Set("scope", "api")
+	form.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.OAuthTokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("error creating oauth token request: %v", err)
+	}
+
+	basic := base64.StdEncoding.EncodeToString([]byte(c.ClientID + ":" + c.ClientSecret))
+	req.Header.Set("Authorization", "Basic "+basic)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error requesting oauth token: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Printf("WARNING: Error closing oauth response body: %v\n", closeErr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading oauth token response: %v", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("oauth token request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", fmt.Errorf("error parsing oauth token response: %v", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("oauth token response contained no access_token")
+	}
+
+	c.bearerToken = tokenResp.AccessToken
+	c.tokenExpiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn-60) * time.Second)
+
+	return c.bearerToken, nil
 }
 
 // DoRequestWithContext makes an HTTP request to the JumpCloud API with context
@@ -137,10 +249,19 @@ func (c *Client) DoRequestWithContext(ctx context.Context, method, path string, 
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 
-	// Set headers
-	// JumpCloud API requires x-api-key header for authentication
+	// Set authentication header.
+	// When OAuth2 service-account credentials are configured, use a Bearer token
+	// from the client_credentials flow; otherwise fall back to the static x-api-key.
 	// See: https://docs.jumpcloud.com/api/authentication
-	req.Header.Set("x-api-key", c.APIKey)
+	if c.ClientID != "" && c.ClientSecret != "" {
+		tok, err := c.ensureBearerToken(ctx)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+	} else {
+		req.Header.Set("x-api-key", c.APIKey)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 

--- a/pkg/apiclient/oauth_test.go
+++ b/pkg/apiclient/oauth_test.go
@@ -1,0 +1,114 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDoRequestWithContextUsesBearerToken verifies that when OAuth2
+// service-account credentials are configured, the client performs the
+// client_credentials flow and sends an Authorization: Bearer header on API
+// requests (instead of x-api-key).
+func TestDoRequestWithContextUsesBearerToken(t *testing.T) {
+	const (
+		clientID     = "test-client-id"
+		clientSecret = "test-client-secret"
+		accessToken  = "test-access-token"
+	)
+
+	var tokenRequests int
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests++
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(clientID+":"+clientSecret))
+		if got := r.Header.Get("Authorization"); got != wantAuth {
+			t.Errorf("token request Authorization = %q, want %q", got, wantAuth)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("token request Content-Type = %q, want application/x-www-form-urlencoded", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parsing token request form: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			t.Errorf("token request grant_type = %q, want client_credentials", got)
+		}
+		if got := r.Form.Get("scope"); got != "api" {
+			t.Errorf("token request scope = %q, want api", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"access_token":"` + accessToken + `","expires_in":3600,"token_type":"Bearer"}`)); err != nil {
+			t.Errorf("writing token response: %v", err)
+		}
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+accessToken {
+			t.Errorf("api request Authorization = %q, want Bearer %s", got, accessToken)
+		}
+		if got := r.Header.Get("x-api-key"); got != "" {
+			t.Errorf("api request unexpectedly sent x-api-key = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"success": true}`)); err != nil {
+			t.Errorf("writing api response: %v", err)
+		}
+	}))
+	defer apiServer.Close()
+
+	client := NewClient(&Config{
+		APIURL:        apiServer.URL,
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		OAuthTokenURL: tokenServer.URL,
+	})
+
+	ctx := context.Background()
+
+	if _, err := client.DoRequestWithContext(ctx, http.MethodGet, "/test", nil); err != nil {
+		t.Fatalf("first request error = %v", err)
+	}
+	// A second request should reuse the cached token (no new token fetch).
+	if _, err := client.DoRequestWithContext(ctx, http.MethodGet, "/test", nil); err != nil {
+		t.Fatalf("second request error = %v", err)
+	}
+
+	if tokenRequests != 1 {
+		t.Errorf("token endpoint hit %d times, want 1 (token should be cached)", tokenRequests)
+	}
+}
+
+// TestDoRequestWithContextFallsBackToAPIKey verifies that without OAuth2
+// credentials the client still sends the static x-api-key header.
+func TestDoRequestWithContextFallsBackToAPIKey(t *testing.T) {
+	const apiKey = "static-api-key"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("x-api-key"); got != apiKey {
+			t.Errorf("api request x-api-key = %q, want %q", got, apiKey)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("api request unexpectedly sent Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"success": true}`)); err != nil {
+			t.Errorf("writing api response: %v", err)
+		}
+	}))
+	defer apiServer.Close()
+
+	client := NewClient(&Config{
+		APIURL: apiServer.URL,
+		APIKey: apiKey,
+	})
+
+	if _, err := client.DoRequestWithContext(context.Background(), http.MethodGet, "/test", nil); err != nil {
+		t.Fatalf("request error = %v", err)
+	}
+}


### PR DESCRIPTION
Two small, backward-compatible additions that make the provider usable for fully-automated, import-based workflows:

## 1. OAuth2 service-account auth (`client_credentials` → Bearer)
JumpCloud now offers OAuth2 service accounts (recommended non-human identity: no seat, no MFA, scoped role, rotatable). This lets the provider use them alongside the existing static `x-api-key`.
- `pkg/apiclient/client.go`: `Config`/`Client` gain `ClientID`/`ClientSecret`/`OAuthTokenURL`; `ensureBearerToken` does the `client_credentials` exchange with caching (60s buffer, mutex-guarded); `DoRequestWithContext` sends `Authorization: Bearer` when client creds are set, else `x-api-key`. **Stdlib only** — `go.mod`/`go.sum` unchanged.
- `jumpcloud/provider.go`: `api_key` → Optional; new `client_id`/`client_secret` (env `JUMPCLOUD_CLIENT_ID`/`_SECRET`); fail fast unless one auth mode is fully set.

## 2. Importer for `jumpcloud_user_group`
`ResourceUserGroup()` had no `Importer`, so existing groups couldn't be adopted via `import {}` / `terraform import` (only `jumpcloud_user` could). Added `schema.ImportStatePassthroughContext`, matching `jumpcloud_user`.

## Compatibility & tests
Fully backward compatible. `go build`/`vet`/`test` pass; added unit tests for the Bearer + `x-api-key` paths and the group Importer. Verified live against a real tenant (token + directory API 200; users and groups import with a clean diff).